### PR TITLE
feat: add multiple image upload

### DIFF
--- a/src/image/image.service.ts
+++ b/src/image/image.service.ts
@@ -39,6 +39,21 @@ export class ImageService {
     });
   }
 
+  async uploadImages(
+    files: Express.Multer.File[],
+  ): Promise<Array<{ uniqueId: string; url: string }>> {
+    try {
+      const uploadPromises = files.map((file) => this.uploadImage(file));
+      return await Promise.all(uploadPromises);
+    } catch (error) {
+      this.logger.error(
+        `Unexpected error during multiple image uploads: ${error.message}`,
+        error.stack,
+      );
+      throw new InternalServerErrorException('Failed to upload images');
+    }
+  }
+
   async uploadImage(file: Express.Multer.File): Promise<{
     uniqueId: string;
     url: string;


### PR DESCRIPTION
# Multiple Image Upload Support

## Changes
- Added support for uploading multiple images in a single request
- Modified `ImageService` to handle batch uploads with concurrent processing
- Updated `ImageController` to accept multiple files using `FilesInterceptor`
- Added comprehensive Swagger documentation for the new functionality

## Technical Details
- Maximum of 10 files per upload request
- Each file maintains existing limits (5MB max, jpg/jpeg/png/svg formats)
- Files are uploaded concurrently using `Promise.all`
- Maintains existing error handling and rollback mechanisms

## API Changes
- Changed request field from `file` to `files` in multipart form data
- Response now returns an array of `{ uniqueId, url }` objects
- All existing validation and error handling preserved

## Testing
- Test with multiple file uploads
- Verify concurrent upload performance
- Ensure proper error handling for partial failures